### PR TITLE
Fixed instagram scraper, based on recent updates from SaveVid.app

### DIFF
--- a/lib/Downloaders/Instagram-Downloader.js
+++ b/lib/Downloaders/Instagram-Downloader.js
@@ -8,17 +8,18 @@ const instagramDl = (url) => {
       if (!global.isUrlFSPR(url) || !/instagram\.com/i.test(url))
         return global.rejectFSPR("Invalid URL: " + url);
 
-      const apiUrl = "https://v3.saveig.app/api/ajaxSearch";
+      const apiUrl = "https://v3.savevid.net/api/ajaxSearch";
       const params = {
         q: url,
         t: "media",
         lang: "en",
+        v: 'v2'
       };
 
       const headers = {
         Accept: "*/*",
-        Origin: "https://saveig.app",
-        Referer: "https://saveig.app/en",
+        Origin: "https://savevid.net",
+        Referer: "https://savevid.net/",
         "Accept-Encoding": "gzip, deflate, br",
         "Accept-Language": "en-US,en;q=0.9",
         "Content-Type": "application/x-www-form-urlencoded",
@@ -40,23 +41,61 @@ const instagramDl = (url) => {
 
       const response = await axios.post(apiUrl, qs.stringify(params), config);
       const responseData = response.data.data;
-      const $ = cheerio.load(responseData);
 
-      const downloadItems = $(".download-items");
       const result = [];
 
-      downloadItems.each((index, element) => {
-        const thumbnailLink = $(element)
-          .find(".download-items__thumb > img")
-          .attr("src");
-        const downloadLink = $(element)
-          .find(".download-items__btn > a")
-          .attr("href");
+      // Extract the obfuscated string part
+      var obfuscatedString = responseData.match(/eval\(function\(h,u,n,t,e,r\)\{.*?\}\("([^"]+)",1,"abcdefghi",1,2,1\)\)/)[1];
 
-        result.push({
-          thumbnail_link: thumbnailLink,
-          download_link: downloadLink,
-        });
+      // Define the decoding function based on the extracted part
+      var _0xc0e = ["","split","0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/","slice","indexOf","","",".","pow","reduce","reverse","0"];
+      function _0xe0c(d, e, f) {
+          var g = _0xc0e[2][_0xc0e[1]](_0xc0e[0]);
+          var h = g[_0xc0e[3]](0, e);
+          var i = g[_0xc0e[3]](0, f);
+          var j = d[_0xc0e[1]](_0xc0e[0])
+              [_0xc0e[10]]()
+              [_0xc0e[9]](function (a, b, c) {
+                  if (h[_0xc0e[4]](b) !== -1) return (a += h[_0xc0e[4]](b) * Math[_0xc0e[8]](e, c));
+              }, 0);
+          var k = _0xc0e[0];
+          while (j > 0) {
+              k = i[j % f] + k;
+              j = (j - (j % f)) / f;
+          }
+          return k || _0xc0e[11];
+      }
+      function decode(obfuscatedString) {
+          return (function (h, u, n, t, e, r) {
+              r = "";
+              for (var i = 0, len = h.length; i < len; i++) {
+                  var s = "";
+                  while (h[i] !== n[e]) {
+                      s += h[i];
+                      i++;
+                  }
+                  for (var j = 0; j < n.length; j++) s = s.replace(new RegExp(n[j], "g"), j);
+                  r += String.fromCharCode(_0xe0c(s, e, 10) - t);
+              }
+              return decodeURIComponent(r);
+          })(obfuscatedString, 1, "abcdefghi", 1, 2, 1);
+      }
+
+      // Decode the obfuscated string
+      var decodedString = decode(obfuscatedString);
+
+      var urls = [];
+      var urlRegex = /https?:\/\/[^\s"]+/g;
+      var match;
+
+      while ((match = urlRegex.exec(decodedString)) !== null) {
+          urls.push(match[0].replace('\\', ''));
+      }
+
+
+      result.push({
+        thumbnail_link: urls[1],
+        download_link: urls[2],
       });
 
       resolve(global.resolveFSPR(result));
@@ -66,19 +105,4 @@ const instagramDl = (url) => {
   });
 };
 
-async function instagramDl2(url) {
-  try {
-    if (!global.isUrlFSPR(url) || !/instagram\.com/i.test(url))
-      return global.rejectFSPR("Invalid URL: " + url);
-    return axios(
-      `https://fongsi-scraper-rest-api.vercel.app/ig?url=${url}`,
-    ).then(({ data }) => {
-      if(!data.status) return global.rejectFSPR(data.message);
-      return global.resolveFSPR(data.data);
-    });
-  } catch (error) {
-    return global.rejectFSPR(error);
-  }
-}
-
-module.exports = instagramDl2;
+module.exports = instagramDl;


### PR DESCRIPTION
SaveVid.app had recent **_obfuscation measures_** on their new version of the API. They also changed their subdomain from savevid.app to v3.savevid.net (Domain change included)

The old API endpoint merely responds with a **_404 error_**, but when the domain is changed to the latter it then responds with an obfuscated stringified javascript code as follows (waiting to be executed on the DOM).

This poses a problem since the scraper is a back-end library and it would be pointless to execute on the DOM.

I then devised a way to decode the obfuscated response by looking at itself. The response from SaveVid is as follows:

```
...javascript code that de-obfuscates the abcbcbcbc string

eval(function()("abcbcbcbbabc...."))
````

**The revised code for the Instagram Downloader module follows these steps**

- De-obfuscate response from server
- Extract the abcbcbcbc string
- Use the calculating functions from the server response
- Evaluate the abcbcbcbc string
- Parse all URLs
- Feed the URLs onto 'thumbnail_link' and 'download_link' JSON keys